### PR TITLE
Allowing multiple restarts

### DIFF
--- a/src/BayesRRm.h
+++ b/src/BayesRRm.h
@@ -97,8 +97,9 @@ class BayesRRm
     double epsilonsum;
     double ytildesum;
 
-    uint iteration_restart = 0;
-    uint iteration_start   = 0;
+    uint iteration_restart      = 0;
+    uint iteration_start        = 0;
+    uint first_saved_it_restart = 0;
 
     BayesRRm(Data &data, Options &opt, const long memPageSize);
     virtual ~BayesRRm();

--- a/src/BayesW.cpp
+++ b/src/BayesW.cpp
@@ -856,7 +856,8 @@ void BayesW::init_from_restart(const int K, const uint M, const uint  Mtot, cons
     init(Ntot,Mtot, fixtot);    
 
     //TODO @@@DT change this function to read the csv file from restart in groups 
-    data.read_mcmc_output_csv_file_bW(opt.mcmcOut, opt.save, K, mu, sigmaG, used_data.alpha, pi_L, iteration_restart);
+    data.read_mcmc_output_csv_file_bW(opt.mcmcOut, opt.save, K, mu, sigmaG, used_data.alpha, pi_L,
+                                      iteration_restart, first_saved_it_restart);
     
     // Set new random seed for the ARS in case of restart. In long run we should use dist object for simulating from uniform distribution
     srand(opt.seed + iteration_restart);
@@ -866,11 +867,13 @@ void BayesW::init_from_restart(const int K, const uint M, const uint  Mtot, cons
 
     MPI_Barrier(MPI_COMM_WORLD);
 
-    data.read_mcmc_output_bet_file(opt.mcmcOut, Mtot, iteration_restart, opt.thin,
+    data.read_mcmc_output_bet_file(opt.mcmcOut,
+                                   Mtot, iteration_restart, first_saved_it_restart, opt.thin,
                                    MrankS, MrankL, use_xfiles_in_restart,
                                    Beta);
 
-    data.read_mcmc_output_cpn_file(opt.mcmcOut, Mtot, iteration_restart, opt.thin,
+    data.read_mcmc_output_cpn_file(opt.mcmcOut,
+                                   Mtot, iteration_restart, first_saved_it_restart, opt.thin,
                                    MrankS, MrankL, use_xfiles_in_restart,
                                    components);
 

--- a/src/data.hpp
+++ b/src/data.hpp
@@ -150,21 +150,23 @@ public:
                                    VectorXd&    epsilon);
 
     void read_mcmc_output_cpn_file(const string mcmcOut, const uint Mtot,
-                                   const uint   iteration_restart, const int thin,
+                                   const uint   iteration_restart, const uint first_saved_it_restart, const int thin,
                                    const int*   MrankS,  const int* MrankL, const bool use_xfiles,
                                    VectorXi&    components);
 
     void read_mcmc_output_bet_file(const string mcmcOut, const uint Mtot,
-                                   const uint   iteration_restart, const int thin,
+                                   const uint   iteration_restart, const uint first_saved_it_restart, const int thin,
                                    const int*   MrankS,  const int* MrankL, const bool use_xfiles,
                                    VectorXd&    Beta);
 
     void read_mcmc_output_csv_file(const string mcmcOut, const uint optSave, const int K,
-                                   VectorXd& sigmaG, double& sigmaE, MatrixXd& pi, uint& iteration_restart);
+                                   VectorXd& sigmaG, double& sigmaE, MatrixXd& pi,
+                                   uint& iteration_restart, uint& first_saved_it_restart);
 
     // Three functions tailored for bW output. Consider using same format in bR
     void read_mcmc_output_csv_file_bW(const string mcmcOut, const uint optSave, const int K, double& mu,
-                                     VectorXd& sigmaG, double& sigmaE, MatrixXd& pi, uint& iteration_restart);
+                                      VectorXd& sigmaG, double& sigmaE, MatrixXd& pi,
+                                      uint& iteration_restart, uint& first_saved_it_restart);
 
     void read_mcmc_output_gam_file_bW(const string mcmcOut, const uint optSave, const int gamma_length,
                                      VectorXd& gamma, uint& iteration_restart);
@@ -172,7 +174,8 @@ public:
     void read_mcmc_output_idx_file_bW(const string mcmcOut, const string ext, const uint length, const uint iteration_restart,
                                      std::vector<int>& markerI);
 
-    void read_mcmc_output_mus_file(const string mcmcOut, const uint  iteration_restart, const int thin,
+    void read_mcmc_output_mus_file(const string mcmcOut,
+                                   const uint  iteration_restart, const uint first_saved_it_restart, const int thin,
                                    double& mu);
 
     void load_data_from_bed_file(const string bedfp, const uint Ntot, const int M,


### PR DESCRIPTION
Tested on SPARSE + SPARSE test case with 6 tasks on full dataset from Marion's hydra_test.sh, case 3 modified with the following sequence:

        echo "@@@@@ REFERENCE"
        cmd="srun -N $N --ntasks-per-node=$TPN --cpus-per-task=$CPT $EXE --number-individuals $NUMINDS --number-markers $NUMSNPS --mpibayes bayesMPI --pheno $phen --chain-length 20 --thin 5 --save 5  --mcmc-out-dir $outdir --mcmc-out-name ${output}_ref --seed $SEED --shuf-mark $SM --sync-rate $SR --sparse-dir $sparsedir  --sparse-basename $sparsebsn --sparse-sync --S $S"
        echo $cmd; echo
        $cmd || exit 1

        echo; echo "@@@@@ FAIL"
        cmd="srun -N $N --ntasks-per-node=$TPN --cpus-per-task=$CPT $EXE --number-individuals $NUMINDS --number-markers $NUMSNPS --mpibayes bayesMPI --pheno $phen --chain-length 7 --thin 5 --save 5  --mcmc-out-dir $outdir --mcmc-out-name $output --seed $SEED --shuf-mark $SM --sync-rate $SR --sparse-dir $sparsedir  --sparse-basename $sparsebsn --sparse-sync --S $S"
        echo $cmd; echo
        $cmd &>/dev/null || exit 1
        
        echo; echo "@@@@@ RESTART + FAIL"
        cmd="srun -N $N --ntasks-per-node=$TPN --cpus-per-task=$CPT $EXE --number-individuals $NUMINDS --number-markers $NUMSNPS --mpibayes bayesMPI --pheno $phen --chain-length 12 --thin 5 --save 5  --mcmc-out-dir $outdir --mcmc-out-name $output --seed $SEED --shuf-mark $SM --sync-rate $SR --sparse-dir $sparsedir  --sparse-basename $sparsebsn --sparse-sync --S $S --restart"
        echo $cmd; echo
        $cmd &>/dev/null || exit 1

        echo; echo "@@@@@ RE-RE-START"
        cmd="srun -N $N --ntasks-per-node=$TPN --cpus-per-task=$CPT $EXE --number-individuals $NUMINDS --number-markers $NUMSNPS --mpibayes bayesMPI --pheno $phen --chain-length 20 --thin 5 --save 5  --mcmc-out-dir $outdir --mcmc-out-name ${output}_rs --seed $SEED --shuf-mark $SM --sync-rate $SR --sparse-dir $sparsedir  --sparse-basename $sparsebsn --sparse-sync --S $S --restart"
        echo $cmd; echo
        $cmd || exit 1

That is:
1. create a reference run
2. "fail" a run
3. restart from first failure and fail again
4. restart from second failed run and complete.

If you concatenate all csv files from faile + restarted job you should get a similar one to the one of the reference run.