### PR TITLE
Fix empty groups handling

### DIFF
--- a/src/BayesRRm.cpp
+++ b/src/BayesRRm.cpp
@@ -939,7 +939,6 @@ int BayesRRm::runMpiGibbs() {
 
     // First, load the mixture components (adding 0.0 as first element/column)
     if (opt.groupIndexFile != "" && opt.groupMixtureFile != "") {
-        printf("READING GROUP INDEX and MIXTURE files\n");
         data.readGroupFile(opt.groupIndexFile);
         data.readmSFile(opt.groupMixtureFile);
     } else {


### PR DESCRIPTION
…oups and gives clean output information

such as 

```
INFO   : global cass on iteration 9:
         Mtot[  0] =        0  | cass:        0        0        0        0        0 -> sum =        0
         Mtot[  1] =        0  | cass:        0        0        0        0        0 -> sum =        0
         Mtot[  2] =        0  | cass:        0        0        0        0        0 -> sum =        0
         Mtot[  3] =        0  | cass:        0        0        0        0        0 -> sum =        0
         Mtot[  4] =        0  | cass:        0        0        0        0        0 -> sum =        0
         Mtot[  5] =        0  | cass:        0        0        0        0        0 -> sum =        0
         Mtot[  6] =      129  | cass:       90        7       25        7        0 -> sum =      129
         Mtot[  7] =       88  | cass:       51        9        9       14        5 -> sum =       88
         Mtot[  8] =      107  | cass:       60       29        0        2       16 -> sum =      107
         Mtot[  9] =      162  | cass:      146        0        0       11        5 -> sum =      162
         Mtot[ 10] =      173  | cass:      143       12        3        2       13 -> sum =      173
         Mtot[ 11] =      225  | cass:      191       14        6        2       12 -> sum =      225
         Mtot[ 12] =       29  | cass:       16        0        8        3        2 -> sum =       29
         Mtot[ 13] =       28  | cass:       13        4        5        0        6 -> sum =       28
         Mtot[ 14] =       29  | cass:       14        5        0        9        1 -> sum =       29
         Mtot[ 15] =       44  | cass:       30        5        3        3        3 -> sum =       44
         Mtot[ 16] =       57  | cass:       29       17        6        1        4 -> sum =       57
         Mtot[ 17] =       62  | cass:       26       13        8       10        5 -> sum =       62
         Mtot[ 18] =      199  | cass:      158        7       25        8        1 -> sum =      199
         Mtot[ 19] =      169  | cass:      124        3        1       17       24 -> sum =      169
         Mtot[ 20] =      268  | cass:      222       25        1       16        4 -> sum =      268
         Mtot[ 21] =      341  | cass:      295       15       12        3       16 -> sum =      341
         Mtot[ 22] =      589  | cass:      557        6        1       21        4 -> sum =      589
         Mtot[ 23] =      469  | cass:      452        4        5        0        8 -> sum =      469
         Mtot[ 24] =      768  | cass:      713       14       11       18       12 -> sum =      768
         Mtot[ 25] =      616  | cass:      591        4       11        0       10 -> sum =      616
         Mtot[ 26] =      812  | cass:      775       11       14        2       10 -> sum =      812
         Mtot[ 27] =      849  | cass:      809       22        0       15        3 -> sum =      849
         Mtot[ 28] =     1978  | cass:     1941        5        2       17       13 -> sum =     1978
         Mtot[ 29] =     1809  | cass:     1777        5        0       12       15 -> sum =     1809
         Mtot[ 30] =        0  | cass:        0        0        0        0        0 -> sum =        0
         Mtot[ 31] =        0  | cass:        0        0        0        0        0 -> sum =        0
         Mtot[ 32] =        0  | cass:        0        0        0        0        0 -> sum =        0
         Mtot[ 33] =        0  | cass:        0        0        0        0        0 -> sum =        0
         Mtot[ 34] =        0  | cass:        0        0        0        0        0 -> sum =        0
         Mtot[ 35] =        0  | cass:        0        0        0        0        0 -> sum =        0
RESULT : it    9, rank    0: proc =     0.389 s, sync =     0.305 (    0.015 +     0.290), n_sync =      334 (     167 +      167) (  0.092 /   1.737), sigmaG =    0.0017700023, sigmaE =    0.9957272682, betasq =    0.0015513625, m0 =        777
```
